### PR TITLE
Compile with core v0.16

### DIFF
--- a/src/xlsx.ml
+++ b/src/xlsx.ml
@@ -238,7 +238,7 @@ let index_of_column s =
       | 'A' .. 'Z' -> true
       | _ -> false)
   in
-  String.Table.find_or_add col_cache key ~default:(fun () ->
+  Hashtbl.find_or_add col_cache key ~default:(fun () ->
       String.fold key ~init:0 ~f:(fun acc c -> (acc * 26) + Char.to_int c - 64) - 1)
 
 let row_width num_cells data =


### PR DESCRIPTION
This pull request allow to compile the library with the latest version of core. The module [String.Table](https://ocaml.org/p/core/v0.16.0/doc/Core/String/Table/index.html) does not include anymore the code from Hashtbl.